### PR TITLE
Fix trimming whitespace from suffixes

### DIFF
--- a/jplag/pom.xml
+++ b/jplag/pom.xml
@@ -2,7 +2,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jplag</artifactId>
-    <version>2.15.3-SNAPSHOT</version>
+    <version>2.15.4-SNAPSHOT</version>
 
     <parent>
         <groupId>edu.kit.ipd.jplag</groupId>

--- a/jplag/src/main/java/jplag/options/CommandLineOptions.java
+++ b/jplag/src/main/java/jplag/options/CommandLineOptions.java
@@ -189,8 +189,7 @@ public class CommandLineOptions extends Options {
                 Vector<String> vsuffies = new Vector<String>();
                 StringTokenizer st = new StringTokenizer(suffixstr, ",");
                 while (st.hasMoreTokens()) {
-    				suffixstr = st.nextToken();
-    				suffixstr.trim();
+    				suffixstr = st.nextToken().trim();
                     if (suffixstr.equals(""))
                         continue;
                     vsuffies.addElement(suffixstr);


### PR DESCRIPTION
Java String objects are immutable, so calling `.trim()` without assigning the
result is completely useless.